### PR TITLE
Parse Headers

### DIFF
--- a/wanbli.du
+++ b/wanbli.du
@@ -87,7 +87,7 @@ class Request {
 
     private parseHeaders(headers) {
         for (var i = 1; i < headers.len(); i += 1) {
-            const headerData = headers[i].split(":");
+            const headerData = headers[i].split(":", 1);
             this.headers[headerData[0]] = headerData[1].strip();
         }
     }


### PR DESCRIPTION
# Parse Headers

Resolves: #2 

## Summary
This should instruct `.split()` to only split on the first occurrence of colon meaning any further colons in the header value are not being lost 