### PR TITLE
Routing

### DIFF
--- a/example.du
+++ b/example.du
@@ -73,7 +73,13 @@ class Books {
             System.exit(1);
         }
     });
-    wanbli.start();
+
+    const error = wanbli.start();
+
+    if (error) {
+        print(error.unwrapError());
+        System.exit(1);
+    }
 
     System.exit(0);
 }

--- a/wanbli.du
+++ b/wanbli.du
@@ -268,7 +268,7 @@ class Wanbli {
     init(host="127.0.0.1", var port=8080) {
         this.server = Server(this.response, host, port);
         this.logger = Log();
-        this.routes = [];
+        this.routes = {};
         this.middleware = {};
         this.sessionHandler = nil;
     }
@@ -309,30 +309,30 @@ class Wanbli {
     }
 
     private dispatch(request) {
-        for (var i = 0; i < this.routes.len(); i += 1) {
-            if (this.routes[i].route == request.route and this.routes[i].verb == request.verb) {
-                var response;
+        const route = this.routes.get(request.route, false);
 
-                const mwCount = this.routes[i].middleware.len();
-                if (mwCount > 0) {
-                    for (var j = 0; j < mwCount; j += 1) {
-                        response = this.routes[i].middleware[j].handle(request, response);
-                        if (response != nil) {
-                            return response;
-                        }
+        if (route and route.verb == request.verb) {
+            var response;
+
+            const mwCount = route.middleware.len();
+            if (mwCount > 0) {
+                for (var j = 0; j < mwCount; j += 1) {
+                    response = route.middleware[j].handle(request, response);
+                    if (response != nil) {
+                        return response;
                     }
                 }
-
-                response = this.routes[i].callback(request);
-
-                if (type(response) == "string") {
-                    response = Response(response);
-                } else {
-                    response = JsonResponse(response);
-                }
-
-                return response;
             }
+
+            response = route.callback(request);
+
+            if (type(response) == "string") {
+                response = Response(response);
+            } else {
+                response = JsonResponse(response);
+            }
+
+            return response;
         }
 
         return this.notFoundHandler(request);
@@ -351,7 +351,7 @@ class Wanbli {
     }
 
     setRoute(route) {
-        this.routes.push(route);
+        this.routes[route.route] = route;
     }
 
     addController(klass) {

--- a/wanbli.du
+++ b/wanbli.du
@@ -275,7 +275,7 @@ class Wanbli {
 
     // start starts the server.
     start() {
-        this.server.start();
+        return this.server.start();
     }
 
     logCall(request, response) {


### PR DESCRIPTION
# Routing
## Summary

Update the routing to use a dictionary rather than a list. We have access to the route so we can index directly to find the route rather than iterate through the list.

Small update but return from `.start()`. I had an issue where a port was already bound and it was not starting and exiting with status code 0